### PR TITLE
Xcode10x can't find com.apple.product-type.tool

### DIFF
--- a/Command-line Tool.xctemplate/TemplateInfo.plist
+++ b/Command-line Tool.xctemplate/TemplateInfo.plist
@@ -31,7 +31,7 @@
 				<string>/usr/bin</string>
 			</dict>
 			<key>ProductType</key>
-			<string>com.apple.product-type.tool</string>
+			<string>com.apple.product-type.library.dynamic</string>
 			<key>BuildPhases</key>
 			<array>
 				<dict>


### PR DESCRIPTION
target specifies product type 'com.apple.product-type.tool', but there's no such product type for the 'iphoneos' platform